### PR TITLE
Fixing tokenizer to select for >=2 instead of 2.  Resolves discrepena…

### DIFF
--- a/BERTTokenizers/Base/TokenizerBase.cs
+++ b/BERTTokenizers/Base/TokenizerBase.cs
@@ -118,7 +118,7 @@ namespace BERTTokenizers.Base
             {
                 string prefix = null;
                 int subwordLength = remaining.Length;
-                while (subwordLength > 2)
+                while (subwordLength >= 2)
                 {
                     string subword = remaining.Substring(0, subwordLength);
                     if (!_vocabularyDict.ContainsKey(subword))

--- a/BERTTokenizersTests/BertBaseTokenizerUncasedShould.cs
+++ b/BERTTokenizersTests/BertBaseTokenizerUncasedShould.cs
@@ -29,6 +29,23 @@ namespace BERTTokenizersTests
         }
 
         [Fact]
+        public void Encode_admin_example()
+        {
+            var sentence = "Joe is an admin";
+
+            var encoded = _tokenizer.Encode(8, sentence);
+            Assert.Equal(8, encoded.Count);
+            Assert.Equal((101, 0, 1), encoded[0]);
+            Assert.Equal((3533, 0, 1), encoded[1]);
+            Assert.Equal((2003, 0, 1), encoded[2]);
+            Assert.Equal((2019, 0, 1), encoded[3]);
+            Assert.Equal((4748, 0, 1), encoded[4]);
+            Assert.Equal((10020, 0, 1), encoded[5]);
+            Assert.Equal((102, 0, 1), encoded[6]);
+            Assert.Equal((0, 0, 0), encoded[7]);
+        }
+
+        [Fact]
         public void Encode_sentence()
         {
             var sentence = "I love you";


### PR DESCRIPTION
Addresses a discrepancy between the tokenizer and native tokenizer (e.g. python) when the word prefix token match is of size 2.  For example, the phrase: "Joe is an admin" maps to [101,3533,2003,2019,4748,10020,102] using the python tokenizer, while it maps to [101,3533,2003,2019,100 (unknown), 102] for the C# tokenizer.  In this case when the token "admin" is being truncated, it winds up with "ad" in the first pass, which should match to token 4748 "ad", but is exited from the loop as it is only of size 2.  Fixing the size check to >=2 aligns with the native python tokenizer.

The outer loop still catches the size 2 when the replacement becomes "##" and will not enter the loop when the replacement is all that is left.

Added a test case to handle the new token match.